### PR TITLE
feat: add Origen translations page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,31 +1,70 @@
 .App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-.App-header {
-  background-color: #282c34;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
+}
+
+.site-header {
+  background-color: #3e5f8a;
+  color: #fff;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+.tagline {
+  font-size: 1.2rem;
+  margin-top: 0.5rem;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  padding: 2rem;
 }
 
-.App-link {
-  color: #61dafb;
+.work-card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  max-width: 300px;
+  padding: 1rem;
 }
 
-.heart {
-  color: #ff0000;
+.work-card h3 {
+  margin-top: 0;
 }
 
-.small {
-  font-size: 0.75rem;
+.original-text {
+  font-style: italic;
+}
+
+.work-card button {
+  margin-top: 1rem;
+  background: #3e5f8a;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.work-card button:hover {
+  background: #2d476b;
+}
+
+.translation {
+  margin-top: 1rem;
+  background: #f0f0f0;
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+
+.footer {
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.8rem;
+  background: #e5e3d8;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,27 +1,22 @@
 import './App.css';
+import WorkCard from './components/WorkCard.jsx';
+import { works } from './data/works.js';
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src="Octocat.png" className="App-logo" alt="logo" />
-        <p>
-          GitHub Codespaces <span className="heart">♥️</span> React
-        </p>
-        <p className="small">
-          Edit <code>src/App.jsx</code> and save to reload.
-        </p>
-        <p>
-          <a
-            className="App-link"
-            href="https://reactjs.org"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Learn React
-          </a>
-        </p>
+      <header className="site-header">
+        <h1>Origen Translations</h1>
+        <p className="tagline">Machine-translated access to the overlooked writings of Origen.</p>
       </header>
+      <main className="content">
+        {works.map((w) => (
+          <WorkCard key={w.id} work={w} />
+        ))}
+      </main>
+      <footer className="footer">
+        Sources are in the public domain. Translations are machine generated.
+      </footer>
     </div>
   );
 }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,9 +1,9 @@
 import { expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import App from './App.jsx';
 
-test('renders learn react link', () => {
+test('renders site title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeDefined();
+  const heading = screen.getByText(/Origen Translations/i);
+  expect(heading).toBeDefined();
 });

--- a/src/components/WorkCard.jsx
+++ b/src/components/WorkCard.jsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { translate } from '../utils/translator.js';
+
+export default function WorkCard({ work }) {
+  const [translation, setTranslation] = useState('');
+
+  const handleTranslate = () => {
+    const result = translate(work.original);
+    setTranslation(result);
+  };
+
+  return (
+    <div className="work-card">
+      <h3>{work.title}</h3>
+      <p className="original-text">{work.original}</p>
+      <button onClick={handleTranslate}>Translate</button>
+      {translation && <p className="translation">{translation}</p>}
+    </div>
+  );
+}

--- a/src/data/works.js
+++ b/src/data/works.js
@@ -1,0 +1,20 @@
+export const works = [
+  {
+    id: 1,
+    title: "Commentary on the Song of Songs",
+    original: "Osculetur me osculo oris sui; meliora sunt ubera tua vino.",
+    language: "la",
+  },
+  {
+    id: 2,
+    title: "Homilies on Ezekiel",
+    original: "Et factum est in trigesimo anno, in quarto mense, quinta mensis.",
+    language: "la",
+  },
+  {
+    id: 3,
+    title: "Fragments on Jeremiah",
+    original: "Quia ego scio cogitationes quas cogito super vos, dicit Dominus.",
+    language: "la",
+  },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,12 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Georgia', serif;
+  background: #f5f2e8;
+  color: #333;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/src/utils/translator.js
+++ b/src/utils/translator.js
@@ -1,0 +1,12 @@
+const translations = {
+  "Osculetur me osculo oris sui; meliora sunt ubera tua vino.":
+    "Let him kiss me with the kiss of his mouth; your love is better than wine.",
+  "Et factum est in trigesimo anno, in quarto mense, quinta mensis.":
+    "And it came to pass in the thirtieth year, in the fourth month, on the fifth day of the month.",
+  "Quia ego scio cogitationes quas cogito super vos, dicit Dominus.":
+    "For I know the thoughts that I think toward you, says the Lord.",
+};
+
+export function translate(text) {
+  return translations[text] || "Translation not available.";
+}


### PR DESCRIPTION
## Summary
- add landing page for Origen translations with sample works and machine translation placeholder
- style cards and global theme
- update tests for new content

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a851d968f48331bd7f9df3e48905c6